### PR TITLE
Add vibeEmu emulator

### DIFF
--- a/emulators/vibeemu.py
+++ b/emulators/vibeemu.py
@@ -1,0 +1,26 @@
+from util import *
+from emulator import Emulator
+from test import *
+import os
+import subprocess
+
+
+class VibeEmu(Emulator):
+    def __init__(self):
+        super().__init__("vibeEmu", "https://github.com/vulcandth/vibeEmu", startup_time=1.0)
+        self.title_check = lambda title: "vibeEmu" in title
+
+    def setup(self):
+        download("https://codeload.github.com/vulcandth/vibeEmu/zip/main", "downloads/vibeemu.zip")
+        extract("downloads/vibeemu.zip", "emu/vibeemu")
+        self.path = os.path.join("emu", "vibeemu", os.listdir("emu/vibeemu")[0])
+        subprocess.Popen(["cargo", "build", "--release"], cwd=self.path).wait()
+        self.exe = os.path.join(self.path, "target", "release", "vibeEmu.exe")
+        setDPIScaling(self.exe)
+        setupMesa(os.path.dirname(self.exe))
+
+    def startProcess(self, rom, *, model, required_features):
+        mode = {DMG: "--dmg", CGB: "--cgb"}.get(model)
+        if mode is None:
+            return None
+        return subprocess.Popen([self.exe, mode, os.path.abspath(rom)], cwd=self.path)

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from emulators.pyboy import PyBoy
 from emulators.ares import Ares
 from emulators.emmy import Emmy
 from emulators.gameroy import GameRoy
+from emulators.vibeemu import VibeEmu
 from util import *
 from test import *
 
@@ -58,6 +59,7 @@ emulators = [
     Ares(),
     Emmy(),
     GameRoy(),
+    VibeEmu(),
 ]
 tests = testroms.acid.all + testroms.blarg.all + testroms.daid.all + testroms.ax6.all + testroms.mooneye.all + testroms.samesuite.all + testroms.hacktix.all + testroms.cpp.all + testroms.mealybug.all
 


### PR DESCRIPTION
## Summary
- add vibeEmu emulator integration
- include vibeEmu in emulator list for tests

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854abbc3f4883259c5780183f8c7d76