### PR TITLE
Add parallel dispatch and improved screenshot capture

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -24,7 +24,19 @@ class Emulator:
         raise NotImplementedError()
 
     def postWindowCreation(self):
-        pass
+        if os.getenv("VIBEEMU_PARALLEL") == "1":
+            import win32gui, win32con
+            hwnd = findWindow(self.title_check)
+            if hwnd:
+                win32gui.SetWindowPos(
+                    hwnd,
+                    None,
+                    -20000,
+                    -20000,
+                    0,
+                    0,
+                    win32con.SWP_NOSIZE | win32con.SWP_NOZORDER,
+                )
 
     def getScreenshot(self):
         return getScreenshot(self.title_check)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pywin32
 selenium
 tqdm
+fasteners


### PR DESCRIPTION
## Summary
- add a `--parallel` flag and worker-based dispatcher
- guard downloads with an interprocess lock
- capture screenshots with PrintWindow for hidden windows
- hide emulator windows off-screen when running in parallel
- add `fasteners` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857104b9f7083258c9f1844f5452dd0